### PR TITLE
Fixed mode selection and added some additional functions

### DIFF
--- a/spi.h
+++ b/spi.h
@@ -7,6 +7,7 @@
 #define SPI_H
 //-----------------------------------------------------------------------------
 #include <linux/spi/spidev.h>
+#include <stdint.h>
 //-----------------------------------------------------------------------------
 // common error codes (return values)
 #define SPI_ERR_NONE        0 // no error, success
@@ -37,7 +38,6 @@ typedef struct spi_ {
   __u8  mode;  // SPI mode
   __u8  lsb;   // LSB first
   __u8  bits;  // bits per word
-  struct spi_ioc_transfer xfer;
 } spi_t;
 //----------------------------------------------------------------------------
 #ifdef __cplusplus
@@ -55,17 +55,29 @@ int spi_init(spi_t *self,
              int bits,           // bits per word (usually 8)
              int speed);         // max speed [Hz]
 //----------------------------------------------------------------------------
+// sets mode on existing spi
+int spi_set_mode(spi_t* self, int mode);
+//----------------------------------------------------------------------------
+// sets speed on existing spi
+int spi_set_speed(spi_t* self, int speed);
+//----------------------------------------------------------------------------
 // close SPIdev file and free memory
 void spi_free(spi_t *self);
 //----------------------------------------------------------------------------
 // read data from SPIdev
-int spi_read(spi_t *self, char *rx_buf, int len);
+int spi_read(spi_t *self, void* rx_buf, int len);
 //----------------------------------------------------------------------------
 // write data to SPIdev
-int spi_write(spi_t *self, const char *tx_buf, int len);
+int spi_write(spi_t *self, const void* tx_buf, int len);
 //----------------------------------------------------------------------------
 // read and write `len` bytes from/to SPIdev
-int spi_exchange(spi_t *self, char *rx_buf, const char *tx_buf, int len);
+int spi_exchange(spi_t *self, void* rx_buf, const void* tx_buf, int len);
+//----------------------------------------------------------------------------
+// read data from SPIdev from specific register address
+int spi_read_reg8(spi_t *self, uint8_t reg_addr, void* rx_buf, int len);
+//----------------------------------------------------------------------------
+// write data to SPIdev to specific register address
+int spi_write_reg8(spi_t *self, uint8_t reg_addr, const void* tx_buf, int len);
 //----------------------------------------------------------------------------
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added:
 - spi_set_mode
 - spi_set_speed
 - spi_read_reg8
 - spi_write_reg8

Fixed: 
 - Setting mode: mode = 0 is a valid mode and with current if check, it isn't applied (eg going from mode 3 to mode 0)
 - modified spi_exchange to allow taking any kind of buffer, and not `char` in particular